### PR TITLE
Add script to create and upload vector tiles

### DIFF
--- a/scripts/vector-tiles.sh
+++ b/scripts/vector-tiles.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+# Generate vector tiles from the Road Network and upload the to S3.
+
+# Create a bucket
+# - Give public read access
+# - Enable CORS (Remove comment)
+
+TMP_DIR=./.tmp
+OUTPUT_DIR=./output
+
+AWS_BUCKET=$1
+
+if [ -z "$AWS_BUCKET" ]; then
+  echo "Bucket name not supplied"
+  echo "Usage:"
+  echo "  bash vector-tiles.sh [bucket]"
+  exit 1
+fi
+
+: "${AWS_ACCESS_KEY_ID?Need to set AWS_ACCESS_KEY_ID}"
+: "${AWS_SECRET_ACCESS_KEY?Need to set AWS_SECRET_ACCESS_KEY}"
+
+# Check if the road network geojson exists.
+if [ ! -f $OUTPUT_DIR/roadnetwork-indicators.geojson ]; then
+  echo 'File roadnetwork-indicators.geojson not found in output directory.'
+  exit 1
+fi
+
+# Delete destination if it exists
+rm -rf $OUTPUT_DIR/roadnetwork-tiles
+
+tippecanoe -e $OUTPUT_DIR/roadnetwork-tiles -l roads $OUTPUT_DIR/roadnetwork-indicators.geojson
+
+aws s3 sync $OUTPUT_DIR/roadnetwork-tiles/ s3://$AWS_BUCKET/ --delete --content-encoding gzip --acl public-read


### PR DESCRIPTION
Generate vector tiles from file and upload result to S3.

Expects:
- Bucket to exist and be passed as agument to the script `bash vector-tiles.sh [bucket]`
- Bucket needs to be manually configured to be publicly readable and have cors enabled (notes on the file)
- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as env variables
- Source file `roadnetwork-indicators.geojson` in the output directory. (This comes from the `merge-indicators.js` See #18)