### PR TITLE
Add AADT indicator Fix #37

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -13,7 +13,7 @@ cat $TMP_DIR/district_boundaries.geojson | ./node_modules/geojson-join/geojson-j
 node ./scripts/indicator-from-areas/index.js .tmp/district_boundaries-fish.geojson ArtFiMean fish-potential
 
 # Calculate agriculture potential for each road segment
-node ./scripts/indicator-from-areas/index.js .tmp/agriculture.geojson ag_bykm agriculture-potential
+node ./scripts/indicator-from-areas/index.js .tmp/agriculture.geojson ag_bykm ag-potential
 
 # Calculate agriculture production for each road segment
 # Add source data for agriculture production to GeoJSON with areas from SPAM
@@ -21,12 +21,15 @@ cat $TMP_DIR/agriculture.geojson | ./node_modules/geojson-join/geojson-join --fo
     ./source/agriculture/v_all.csv \
     --againstField=ALLOC_KEY \
     --geojsonField=alloc_key > $TMP_DIR/agriculture-production.geojson
-node ./scripts/indicator-from-areas/index.js .tmp/agriculture-production.geojson v_all agriculture-production
+node ./scripts/indicator-from-areas/index.js .tmp/agriculture-production.geojson v_all ag-production
 
 # Calculate poverty rate for each road segment
 node ./scripts/indicator-from-areas/index.js .tmp/district_boundaries.geojson POV_HCR poverty
 
-# Calculate script
+# Add normalized AADT score for each segment
+node ./scripts/indicator-from-prop/index.js AADT
+
+# Calculate link criticality
 bash scripts/criticality/criticality.sh
 
 # Attach indicators to RN

--- a/scripts/filter-percentile/filter-percentile.js
+++ b/scripts/filter-percentile/filter-percentile.js
@@ -1,14 +1,14 @@
 'use strict';
 import fs from 'fs-extra';
 import path from 'path';
-import {featureCollection} from '@turf/helpers';
+import { featureCollection } from '@turf/helpers';
 
 import nodeCleanup from 'node-cleanup';
 
-import {tStart, tEnd, jsonToFile} from '../utils/logging';
+import { tStart, tEnd } from '../utils/logging';
 
 /**
- * This script filters GeoJSON features by one of the properties and returns 
+ * This script filters GeoJSON features by one of the properties and returns
  * those outside a percentile rank. (eg. all features which length is above the
  * 80th percentile).
  */
@@ -48,7 +48,7 @@ clog('Loading source data');
 const data = fs.readJsonSync(SRC_FILE);
 
 /**
- * Calculates the percentile rank 
+ * Calculates the percentile rank
  *
  * @param  {Object} data        GeoJSON FeatureCollection.
  * @param  {String} targetFile  Path of the exported file.
@@ -68,7 +68,7 @@ async function run (data, targetFile, property, percentile) {
   let percentileValue = valueList[ordinalRank];
 
   // Filter the data and include everything outside the percentile rank
-  let filteredFeatures = data.features.filter(f => f.properties[property] >= percentileValue)
+  let filteredFeatures = data.features.filter(f => f.properties[property] >= percentileValue);
 
   return fs.writeFile(TARGET_FILE, JSON.stringify(featureCollection(filteredFeatures)));
 }
@@ -82,7 +82,6 @@ async function run (data, targetFile, property, percentile) {
     tStart(`Total run time`)();
     await run(data, TARGET_FILE, PROPERTY, PERCENTILE);
     tEnd(`Total run time`)();
-
   } catch (e) {
     console.log(e);
   }

--- a/scripts/indicator-from-prop/index.js
+++ b/scripts/indicator-from-prop/index.js
@@ -1,0 +1,10 @@
+// only ES5 is allowed in this file
+require('babel-register')({
+  presets: [ 'es2015' ],
+  plugins: [ 'transform-regenerator', 'syntax-async-functions' ]
+});
+
+require('babel-polyfill');
+
+// load the server
+require('./indicator-from-prop.js');

--- a/scripts/indicator-from-prop/indicator-from-prop.js
+++ b/scripts/indicator-from-prop/indicator-from-prop.js
@@ -1,0 +1,82 @@
+'use strict';
+import fs from 'fs-extra';
+import path from 'path';
+import Promise from 'bluebird';
+
+import { dataToCSV } from '../utils/utils';
+import { tStart, tEnd, initLog } from '../utils/logging';
+
+/**
+ * This script normalizes an indicator from the road network file
+ *
+ * It requires the GeoJSON with road network data - hardcoded
+ *
+ *
+ * Usage:
+ *  $node ./scripts/indicator-from-prop.js AADT
+ *
+ */
+
+// This script requires 1 parameters.
+const [, , PROPERTY] = process.argv;
+
+if (!PROPERTY) {
+  console.log(`This script requires one parameter to run:
+  1. the property of the road segment to generate the normalized score from
+  
+  Eg. $ node ./scripts/indicator-from-prop.js AADT`);
+
+  process.exit(1);
+}
+
+// //////////////////////////////////////////////////////////
+// Config Vars
+
+const OUTPUT_DIR = path.resolve(__dirname, '../../.tmp');
+const LOG_DIR = path.resolve(__dirname, '../../log/indicator-from-prop');
+
+const indName = `${PROPERTY.toLowerCase()}-score`;
+
+const RN_FILE = path.resolve(OUTPUT_DIR, 'roadnetwork.geojson');
+const OUTPUT_INDICATOR_FILE = path.resolve(OUTPUT_DIR, `indicator-${indName}.csv`);
+
+const clog = initLog(`${LOG_DIR}/log-${Date.now()}.txt`);
+
+clog('Loading Road Network');
+const ways = fs.readJsonSync(RN_FILE).features;
+
+/**
+ * Generate a normalized score for a property on each way
+ *
+ * @param  {Array} ways         Road network ways.
+ * @param  {String} indProperty Property to get value from.
+ *
+ * @return Promise{}            Resolves when file was written.
+ */
+async function run (ways, indProperty) {
+  const maxScore = Math.max(...ways.map(way => way.properties[indProperty]));
+
+  const waysScore = ways.map(way => ({
+    way_id: way.properties.NAME,
+    score: Math.round(way.properties[indProperty] / maxScore * 100)
+  }));
+
+  const csv = await dataToCSV(waysScore);
+  return fs.writeFile(OUTPUT_INDICATOR_FILE, csv);
+}
+
+(async function main () {
+  try {
+    await Promise.all([
+      fs.ensureDir(OUTPUT_DIR),
+      fs.ensureDir(LOG_DIR)
+    ]);
+
+    tStart(`Total run time`)();
+
+    await run(ways, PROPERTY);
+    tEnd(`Total run time`)();
+  } catch (e) {
+    console.log(e);
+  }
+}());


### PR DESCRIPTION
This PR:

- adds a script to calculate a normalized score for a property on the road network data
- it uses ^ script to add an AADT indicator to the pipeline
- does a couple of minor fixes to correct wrong indicator names and linting errors